### PR TITLE
io.c: fix possible buffer overflow in find_all_devices_ccc()

### DIFF
--- a/src/opensuperclone/io.c
+++ b/src/opensuperclone/io.c
@@ -6258,7 +6258,7 @@ int find_all_devices_ccc(void)
       sscanf(line, "%s %s %s %[^\n]", name, raw_size, raw_bytes_per_sec, model);
       strcpy(drive_list_ccc[device_count_ccc], "/dev/");
       strcat(drive_list_ccc[device_count_ccc], name);
-      strncpy(model_ccc[device_count_ccc], model, sizeof(model_ccc));
+      strncpy(model_ccc[device_count_ccc], model, sizeof(model_ccc[device_count_ccc]) - 1);
       // get device info
       long long size = strtoull(raw_size, NULL, 0);
       long long bytes_per_sec = strtoull(raw_bytes_per_sec, NULL, 0);


### PR DESCRIPTION
Was causing crash with -D_FORTIFY_SOURCE=3